### PR TITLE
Fix null gift option check in order checker

### DIFF
--- a/spec/Service/OrderGiftCheckerSpec.php
+++ b/spec/Service/OrderGiftCheckerSpec.php
@@ -56,4 +56,18 @@ class OrderGiftCheckerSpec extends ObjectBehavior
         $giftOption->getOrderNote()->willReturn('GIFT');
         $this->isOrderGift($order)->shouldReturn(false);
     }
+
+    function it_returns_false_when_gift_option_does_not_exist(
+        OrderInterface $order,
+        ChannelInterface $channel,
+        GiftOptionRepositoryInterface $repository
+    ): void {
+        $this->beConstructedWith($repository);
+        $order->getChannel()->willReturn($channel);
+        $repository->findByChannel($channel)->willReturn(null);
+
+        $order->getNotes()->shouldNotBeCalled();
+
+        $this->isOrderGift($order)->shouldReturn(false);
+    }
 }

--- a/src/Service/OrderGiftChecker.php
+++ b/src/Service/OrderGiftChecker.php
@@ -19,8 +19,12 @@ class OrderGiftChecker implements OrderGiftCheckerInterface
     {
         /** @var ChannelInterface $channel */
         $channel = $order->getChannel();
-        /** @var GiftOptionInterface $giftOption */
+        /** @var GiftOptionInterface|null $giftOption */
         $giftOption = $this->giftOptionRepository->findByChannel($channel);
+
+        if ($giftOption === null) {
+            return false;
+        }
 
         return str_contains($order->getNotes() ?? '', $giftOption->getOrderNote()) === true;
     }


### PR DESCRIPTION
## Summary
- ensure `OrderGiftChecker` gracefully handles absence of gift options
- add spec covering the missing gift option case

## Testing
- `composer install --no-interaction` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68725318cf2c8321a8d0c7098379fecd